### PR TITLE
Update Rust edition list to include 2021

### DIFF
--- a/site/static/schemas/rustfmt.toml.json
+++ b/site/static/schemas/rustfmt.toml.json
@@ -94,7 +94,7 @@
       "type": "string",
       "description": "The edition of the parser (RFC 2052)",
       "default": "2015",
-      "enum": ["2015", "2018"]
+      "enum": ["2015", "2018", "2021"]
     },
     "newline_style": {
       "type": "string",


### PR DESCRIPTION
Rust 1.56 (current stable, at the time of this writing) has introduced [Rust Edition 2021](https://doc.rust-lang.org/edition-guide/rust-2021/index.html). This commit updates the list to prevent erroneously showing an error in a Cargo.toml that uses it.